### PR TITLE
Limit data mover name

### DIFF
--- a/api/handlers_movers.go
+++ b/api/handlers_movers.go
@@ -48,6 +48,11 @@ func (s *server) MoverCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(*req.Name) > 40 {
+		handleError(w, apierror.New(apierror.ErrBadRequest, "Name cannot exceed 40 characters ", nil))
+		return
+	}
+
 	regexName := "^[a-zA-Z0-9-]+$"
 	re := regexp.MustCompile(regexName)
 	if !re.MatchString(*req.Name) {

--- a/api/orchestration_movers.go
+++ b/api/orchestration_movers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"hash/crc32"
 	"strings"
 	"time"
 
@@ -302,7 +303,8 @@ func (o *datasyncOrchestrator) createDatasyncLocation(ctx context.Context, mover
 		// we need to generate that first, before creating the location
 
 		path := fmt.Sprintf("/spinup/%s/%s/", o.server.org, group)
-		roleName := fmt.Sprintf("%s-%s", mover, s3Arn.Resource)
+		// use an 8-char CRC32 hash based on the bucket name to limit the length of the role name
+		roleName := fmt.Sprintf("%s-%08x", mover, crc32.ChecksumIEEE([]byte(s3Arn.Resource)))
 
 		roleARN, err := o.bucketAccessRole(ctx, path, roleName, s3Arn.String(), tags)
 		if err != nil {


### PR DESCRIPTION
Check that data mover name doesn't exceed 40 characters and limit the generated role name by hashing the S3 bucket name.

Tested with a long name (MyNewTestMoverWithVeryLongName-1234567), the generated role name looks like this:
`MyNewTestMoverWithVeryLongName-1234567-189ffc09`
